### PR TITLE
Add PN532 RFID backend and configurable reader selection

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -28,13 +28,30 @@ static constexpr const char *const WIFI_PASSWORD = SECRET_WIFI_PASSWORD;
 static constexpr const char *const BACKEND_HOST  = SECRET_BACKEND_HOST;
 static constexpr uint16_t         BACKEND_PORT  = SECRET_BACKEND_PORT;
 
-// Hardware pin definitions. These default values correspond to a
-// typical ESP32 dev kit wired to an MFRC522 module via SPI and using
-// the built‑in LED for feedback. Update these constants to match
-// your wiring. If your previous project used different GPIOs, set
-// them here accordingly to preserve compatibility.
+// RFID/NFC reader selection. Choose which hardware backend should be
+// compiled into the firmware. Add new enum values if additional reader
+// types are supported in the future.
+enum class RfidHardwareType { RC522, PN532 };
+
+// Select the active reader for this build. The default remains the
+// MFRC522 as it was the original hardware target. Change this constant
+// to `RfidHardwareType::PN532` when wiring a PN532 breakout instead.
+static constexpr RfidHardwareType NFC_READER_TYPE = RfidHardwareType::RC522;
+
+// Hardware pin definitions. These defaults correspond to common ESP32
+// development board layouts. Update them to match your wiring. The
+// RC522 uses SPI while the PN532 is configured for I²C by default.
 static constexpr uint8_t NFC_SS_PIN  = 5;   // SPI SS pin (SDA/SS) for RC522
 static constexpr uint8_t NFC_RST_PIN = 27;  // Reset pin for RC522
+
+// PN532 (I²C) wiring defaults. IRQ and reset are optional on some
+// boards, but defining them here keeps the setup consistent. SDA/SCL
+// default to the standard ESP32 I²C pins.
+static constexpr uint8_t PN532_IRQ_PIN  = 4;   // IRQ pin from PN532 to ESP32
+static constexpr uint8_t PN532_RST_PIN  = 16;  // Optional PN532 reset pin
+static constexpr uint8_t PN532_SDA_PIN  = 21;  // I²C SDA
+static constexpr uint8_t PN532_SCL_PIN  = 22;  // I²C SCL
+
 static constexpr uint8_t LED_PIN     = 2;   // On‑board LED (GPIO2 on most ESP32)
 
 // Debounce interval (ms) to ignore repeated reads of the same card.

--- a/include/README
+++ b/include/README
@@ -1,37 +1,25 @@
+# Header files
 
-This directory is intended for project header files.
+This folder contains the public headers for the firmware. The most
+relevant files for day-to-day configuration are:
 
-A header file is a file containing C declarations and macro definitions
-to be shared between several project source files. You request the use of a
-header file in your project source file (C, C++, etc) located in `src` folder
-by including it, with the C preprocessing directive `#include'.
+- `Config.h` – compile-time constants such as Wi-Fi credentials,
+  backend host and RFID reader wiring. New constants include the
+  `RfidHardwareType` enum, the `NFC_READER_TYPE` selector and the
+  default pin assignments for both MFRC522 (SPI) and PN532 (I²C)
+  breakouts. Adjust these values to match your hardware.
+- `RfidReader.h` – façade for the RFID hardware. The reader now
+  instantiates the proper backend automatically based on
+  `NFC_READER_TYPE`, so application code only needs to call
+  `RfidReader::begin()` and `RfidReader::readCard()`.
 
-```src/main.c
+To switch between RC522 and PN532 hardware, edit `Config.h` and set:
 
-#include "header.h"
-
-int main (void)
-{
- ...
-}
+```cpp
+static constexpr RfidHardwareType NFC_READER_TYPE = RfidHardwareType::PN532;
 ```
 
-Including a header file produces the same results as copying the header file
-into each source file that needs it. Such copying would be time-consuming
-and error-prone. With a header file, the related declarations appear
-in only one place. If they need to be changed, they can be changed in one
-place, and programs that include the header file will automatically use the
-new version when next recompiled. The header file eliminates the labor of
-finding and changing all the copies as well as the risk that a failure to
-find one copy will result in inconsistencies within a program.
-
-In C, the convention is to give header files names that end with `.h'.
-
-Read more about using header files in official GCC documentation:
-
-* Include Syntax
-* Include Operation
-* Once-Only Headers
-* Computed Includes
-
-https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html
+Then update the relevant pin constants (`NFC_SS_PIN`/`NFC_RST_PIN` for the
+RC522 or `PN532_IRQ_PIN`, `PN532_RST_PIN`, `PN532_SDA_PIN`, `PN532_SCL_PIN`
+for the PN532). Rebuild and upload the firmware – the rest of the code
+path is hardware-agnostic.

--- a/include/RfidReader.h
+++ b/include/RfidReader.h
@@ -9,15 +9,23 @@
 
 #pragma once
 
-#include <MFRC522.h>
-#include <SPI.h>
+#include <Arduino.h>
+#include <memory>
+
+class IRfidBackend {
+public:
+  virtual ~IRfidBackend() = default;
+  virtual bool begin() = 0;
+  virtual bool readCard(String &uidHex) = 0;
+};
 
 class RfidReader {
 public:
   /**
-   * Initialise the RC522 reader. Provide the SPI SS and reset pins.
+   * Initialise the configured RFID/NFC backend. Pin assignments and
+   * hardware type are defined in Config.h.
    */
-  void begin(uint8_t ssPin, uint8_t rstPin);
+  void begin();
 
   /**
    * Attempt to read a card UID. Returns true if a new card is
@@ -27,5 +35,5 @@ public:
   bool readCard(String &uidHex);
 
 private:
-  MFRC522 _mfrc522;
+  std::unique_ptr<IRfidBackend> _backend;
 };

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,6 +19,7 @@ lib_deps =
   miguelbalboa/MFRC522@^1.4.11
   arduino-libraries/ArduinoHttpClient@^0.6.1
   bblanchon/ArduinoJson@^7.0.0
+  adafruit/Adafruit PN532@^1.3.0
 
 ; Increase debug level by changing CORE_DEBUG_LEVEL (0–5) in build_flags.
 build_flags =

--- a/src/RfidReader.cpp
+++ b/src/RfidReader.cpp
@@ -1,78 +1,186 @@
 /*
  * RfidReader.cpp
  *
- * Enhanced RfidReader implementation with debugging
+ * Backend-agnostic RFID/NFC reader façade. Selects the correct backend
+ * implementation at compile time based on Config.h constants.
  */
 
 #include "RfidReader.h"
 
-void RfidReader::begin(uint8_t ssPin, uint8_t rstPin) {
-  Serial.printf("[RFID] Initializing with SS=%d, RST=%d\n", ssPin, rstPin);
-  
-  // Initialize SPI
-  SPI.begin();
-  Serial.println("[RFID] SPI initialized");
-  
-  // Create MFRC522 instance
-  _mfrc522 = MFRC522(ssPin, rstPin);
-  
-  // Initialize the MFRC522
-  _mfrc522.PCD_Init(ssPin, rstPin);
-  Serial.println("[RFID] MFRC522 initialized");
-  
-  // Test if we can communicate with the chip
-  byte version = _mfrc522.PCD_ReadRegister(MFRC522::VersionReg);
-  Serial.printf("[RFID] MFRC522 version: 0x%02X ", version);
-  
-  if (version == 0x00 || version == 0xFF) {
-    Serial.println("- Communication problem or invalid chip!");
-    Serial.println("[RFID] Check your wiring and power supply");
-  } else {
+#include <MFRC522.h>
+#include <SPI.h>
+#include <Wire.h>
+#include <Adafruit_PN532.h>
+
+#include "Config.h"
+
+namespace {
+
+String bytesToHexString(const uint8_t *buffer, size_t length) {
+  String uidHex;
+  uidHex.reserve(length * 2);
+  for (size_t i = 0; i < length; ++i) {
+    if (buffer[i] < 0x10) {
+      uidHex += '0';
+    }
+    uidHex += String(buffer[i], HEX);
+  }
+  uidHex.toUpperCase();
+  return uidHex;
+}
+
+class Rc522Backend final : public IRfidBackend {
+public:
+  Rc522Backend(uint8_t ssPin, uint8_t rstPin)
+      : _ssPin(ssPin), _rstPin(rstPin), _mfrc522(ssPin, rstPin) {}
+
+  bool begin() override {
+    Serial.printf("[RFID] Initializing RC522 with SS=%d, RST=%d\n", _ssPin, _rstPin);
+
+    SPI.begin();
+    Serial.println("[RFID] SPI initialized");
+
+    _mfrc522.PCD_Init();
+    Serial.println("[RFID] MFRC522 initialized");
+
+    byte version = _mfrc522.PCD_ReadRegister(MFRC522::VersionReg);
+    Serial.printf("[RFID] MFRC522 version: 0x%02X ", version);
+
+    if (version == 0x00 || version == 0xFF) {
+      Serial.println("- Communication problem or invalid chip!");
+      Serial.println("[RFID] Check your wiring and power supply");
+      return false;
+    }
+
     Serial.println("- OK!");
-    // Show some details of the PCD - MFRC522 Card Reader
     _mfrc522.PCD_DumpVersionToSerial();
+    return true;
+  }
+
+  bool readCard(String &uidHex) override {
+    if (!_mfrc522.PICC_IsNewCardPresent()) {
+      return false;
+    }
+
+    Serial.println("[RFID] New card detected, attempting to read...");
+
+    if (!_mfrc522.PICC_ReadCardSerial()) {
+      Serial.println("[RFID] Failed to read card serial");
+      return false;
+    }
+
+    Serial.printf("[RFID] Card read successfully, UID size: %d bytes\n", _mfrc522.uid.size);
+
+    uidHex = bytesToHexString(_mfrc522.uid.uidByte, _mfrc522.uid.size);
+    Serial.printf("[RFID] UID as hex string: %s\n", uidHex.c_str());
+
+    MFRC522::PICC_Type piccType = _mfrc522.PICC_GetType(_mfrc522.uid.sak);
+    Serial.printf("[RFID] Card type: %s\n", _mfrc522.PICC_GetTypeName(piccType));
+
+    _mfrc522.PICC_HaltA();
+    _mfrc522.PCD_StopCrypto1();
+    return true;
+  }
+
+private:
+  uint8_t  _ssPin;
+  uint8_t  _rstPin;
+  MFRC522 _mfrc522;
+};
+
+class Pn532Backend final : public IRfidBackend {
+public:
+  Pn532Backend(uint8_t irqPin, uint8_t resetPin, uint8_t sdaPin, uint8_t sclPin)
+      : _irqPin(irqPin),
+        _resetPin(resetPin),
+        _sdaPin(sdaPin),
+        _sclPin(sclPin),
+        _pn532(irqPin, resetPin) {}
+
+  bool begin() override {
+    Serial.printf("[RFID] Initializing PN532 (IRQ=%d, RST=%d, SDA=%d, SCL=%d)\n",
+                  _irqPin, _resetPin, _sdaPin, _sclPin);
+
+    Wire.begin(_sdaPin, _sclPin);
+    Serial.println("[RFID] I2C bus initialized");
+
+    _pn532.begin();
+
+    uint32_t version = _pn532.getFirmwareVersion();
+    if (!version) {
+      Serial.println("[RFID] Failed to find PN532. Check wiring.");
+      return false;
+    }
+
+    Serial.printf("[RFID] PN532 firmware: v%lu.%lu (0x%08lX)\n",
+                  (version >> 24) & 0xFF, (version >> 16) & 0xFF, version);
+
+    if (!_pn532.SAMConfig()) {
+      Serial.println("[RFID] PN532 SAM configuration failed");
+      return false;
+    }
+
+    Serial.println("[RFID] PN532 ready for passive reads");
+    _initialised = true;
+    return true;
+  }
+
+  bool readCard(String &uidHex) override {
+    if (!_initialised) {
+      return false;
+    }
+
+    uint8_t uid[7];
+    uint8_t uidLength = 0;
+
+    bool success = _pn532.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength, 1000);
+    if (!success) {
+      return false;
+    }
+
+    Serial.printf("[RFID] PN532 detected card, UID length: %d bytes\n", uidLength);
+    uidHex = bytesToHexString(uid, uidLength);
+    Serial.printf("[RFID] UID as hex string: %s\n", uidHex.c_str());
+    return true;
+  }
+
+private:
+  uint8_t          _irqPin;
+  uint8_t          _resetPin;
+  uint8_t          _sdaPin;
+  uint8_t          _sclPin;
+  Adafruit_PN532   _pn532;
+  bool             _initialised = false;
+};
+
+}  // namespace
+
+void RfidReader::begin() {
+  switch (NFC_READER_TYPE) {
+    case RfidHardwareType::RC522:
+      _backend = std::make_unique<Rc522Backend>(NFC_SS_PIN, NFC_RST_PIN);
+      break;
+    case RfidHardwareType::PN532:
+      _backend = std::make_unique<Pn532Backend>(PN532_IRQ_PIN, PN532_RST_PIN,
+                                                PN532_SDA_PIN, PN532_SCL_PIN);
+      break;
+    default:
+      Serial.println("[RFID] Unsupported reader type selected");
+      _backend.reset();
+      return;
+  }
+
+  if (_backend && !_backend->begin()) {
+    Serial.println("[RFID] Backend initialisation failed");
+    _backend.reset();
   }
 }
 
 bool RfidReader::readCard(String &uidHex) {
-  // Look for new cards
-  if (!_mfrc522.PICC_IsNewCardPresent()) {
-    return false; // No card present, this is normal
-  }
-  
-  Serial.println("[RFID] New card detected, attempting to read...");
-  
-  if (!_mfrc522.PICC_ReadCardSerial()) {
-    Serial.println("[RFID] Failed to read card serial");
+  if (!_backend) {
+    Serial.println("[RFID] No reader backend is initialised");
     return false;
   }
-  
-  Serial.printf("[RFID] Card read successfully, UID size: %d bytes\n", _mfrc522.uid.size);
-  
-  // Convert UID bytes to uppercase hex string
-  uidHex = "";
-  Serial.print("[RFID] UID bytes: ");
-  for (byte i = 0; i < _mfrc522.uid.size; ++i) {
-    byte val = _mfrc522.uid.uidByte[i];
-    Serial.printf("0x%02X ", val);
-    
-    if (val < 0x10) {
-      uidHex += '0';
-    }
-    uidHex += String(val, HEX);
-  }
-  Serial.println();
-  uidHex.toUpperCase();
-  
-  Serial.printf("[RFID] UID as hex string: %s\n", uidHex.c_str());
-  
-  // Show card type
-  MFRC522::PICC_Type piccType = _mfrc522.PICC_GetType(_mfrc522.uid.sak);
-  Serial.printf("[RFID] Card type: %s\n", _mfrc522.PICC_GetTypeName(piccType));
-  
-  // Halt the PICC and stop encryption so other tags can be read
-  _mfrc522.PICC_HaltA();
-  _mfrc522.PCD_StopCrypto1();
-  
-  return true;
+
+  return _backend->readCard(uidHex);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,8 +75,7 @@ void setup() {
 
   // Initialise NFC reader
   Serial.println("Initializing NFC reader...");
-  Serial.printf("NFC SS Pin: %d, RST Pin: %d\n", NFC_SS_PIN, NFC_RST_PIN);
-  rfid.begin(NFC_SS_PIN, NFC_RST_PIN);
+  rfid.begin();
   Serial.println("NFC reader initialized");
 
   Serial.println("=================================");


### PR DESCRIPTION
## Summary
- add compile-time configuration for selecting between RC522 and PN532 readers, including default pin assignments
- refactor the RFID reader façade to delegate to backend implementations and introduce a PN532 backend over I²C
- update the main setup flow, documentation, and dependencies to reflect the new hardware options

## Testing
- `pio run` *(fails: PlatformIO CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbc5286008320b848dd6aae10cf2e