### PR TITLE
Set default PlatformIO environment to RC522 build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,10 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:az-delivery-devkit-v4]
+[platformio]
+default_envs = az-delivery-devkit-v4-rc522
+
+[env]
 platform = espressif32
 board = az-delivery-devkit-v4
 framework = arduino
@@ -24,3 +27,9 @@ lib_deps =
 ; Increase debug level by changing CORE_DEBUG_LEVEL (0–5) in build_flags.
 build_flags =
   -DCORE_DEBUG_LEVEL=3
+
+[env:az-delivery-devkit-v4-rc522]
+extends = env
+
+[env:az-delivery-devkit-v4-pn532]
+extends = env


### PR DESCRIPTION
## Summary
- add a global [platformio] section that scopes the default build to the RC522 environment
- split the shared configuration into a base [env] section with explicit RC522 and PN532 environments

## Testing
- pio run *(fails: PlatformIO CLI not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddca05d98083209b8b2419d708fe05