### PR TITLE
Configure mutually exclusive RFID reader builds

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -30,13 +30,23 @@ static constexpr uint16_t         BACKEND_PORT  = SECRET_BACKEND_PORT;
 
 // RFID/NFC reader selection. Choose which hardware backend should be
 // compiled into the firmware. Add new enum values if additional reader
-// types are supported in the future.
+// types are supported in the future. Exactly one of the build flags
+// USE_RC522 or USE_PN532 must be defined (see platformio.ini); they
+// control which driver is compiled and must match the selection below.
 enum class RfidHardwareType { RC522, PN532 };
 
 // Select the active reader for this build. The default remains the
 // MFRC522 as it was the original hardware target. Change this constant
 // to `RfidHardwareType::PN532` when wiring a PN532 breakout instead.
 static constexpr RfidHardwareType NFC_READER_TYPE = RfidHardwareType::RC522;
+
+#if defined(USE_RC522)
+static_assert(NFC_READER_TYPE == RfidHardwareType::RC522,
+              "NFC_READER_TYPE must be RfidHardwareType::RC522 when USE_RC522 is defined.");
+#elif defined(USE_PN532)
+static_assert(NFC_READER_TYPE == RfidHardwareType::PN532,
+              "NFC_READER_TYPE must be RfidHardwareType::PN532 when USE_PN532 is defined.");
+#endif
 
 // Hardware pin definitions. These defaults correspond to common ESP32
 // development board layouts. Update them to match your wiring. The

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:az-delivery-devkit-v4]
+[env]
 platform = espressif32
 board = az-delivery-devkit-v4
 framework = arduino
@@ -16,11 +16,31 @@ framework = arduino
 monitor_speed = 115200
 
 lib_deps =
-  miguelbalboa/MFRC522@^1.4.11
   arduino-libraries/ArduinoHttpClient@^0.6.1
   bblanchon/ArduinoJson@^7.0.0
-  adafruit/Adafruit PN532@^1.3.0
 
 ; Increase debug level by changing CORE_DEBUG_LEVEL (0–5) in build_flags.
 build_flags =
   -DCORE_DEBUG_LEVEL=3
+
+[env:az-delivery-devkit-v4-rc522]
+extends = env
+
+lib_deps =
+  ${env.lib_deps}
+  miguelbalboa/MFRC522@^1.4.11
+
+build_flags =
+  ${env.build_flags}
+  -DUSE_RC522
+
+[env:az-delivery-devkit-v4-pn532]
+extends = env
+
+lib_deps =
+  ${env.lib_deps}
+  adafruit/Adafruit PN532@^1.3.0
+
+build_flags =
+  ${env.build_flags}
+  -DUSE_PN532


### PR DESCRIPTION
## Summary
- split the PlatformIO configuration into shared settings with dedicated RC522 and PN532 environments that define mutually exclusive build flags
- wrap driver includes, backend implementations, and switch branches in preprocessor guards with compile-time errors when incompatible flags are set
- document the new USE_RC522/USE_PN532 flags in Config.h and assert the selected NFC reader type matches the active driver

## Testing
- Not run (PlatformIO CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ddc8645d1c8320ac50929eabd7ffd0