### PR TITLE
Align NFC reader selection with build flags

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -30,22 +30,19 @@ static constexpr uint16_t         BACKEND_PORT  = SECRET_BACKEND_PORT;
 
 // RFID/NFC reader selection. Choose which hardware backend should be
 // compiled into the firmware. Add new enum values if additional reader
-// types are supported in the future. Exactly one of the build flags
-// USE_RC522 or USE_PN532 must be defined (see platformio.ini); they
-// control which driver is compiled and must match the selection below.
+// types are supported in the future. The PlatformIO environment
+// declares USE_RC522 (default) or USE_PN532 to select the appropriate
+// driver, and this block mirrors that choice.
 enum class RfidHardwareType { RC522, PN532 };
 
-// Select the active reader for this build. The default remains the
-// MFRC522 as it was the original hardware target. Change this constant
-// to `RfidHardwareType::PN532` when wiring a PN532 breakout instead.
-static constexpr RfidHardwareType NFC_READER_TYPE = RfidHardwareType::RC522;
-
-#if defined(USE_RC522)
-static_assert(NFC_READER_TYPE == RfidHardwareType::RC522,
-              "NFC_READER_TYPE must be RfidHardwareType::RC522 when USE_RC522 is defined.");
+#if defined(USE_PN532) && defined(USE_RC522)
+#  error "Only one of USE_PN532 or USE_RC522 may be defined."
 #elif defined(USE_PN532)
-static_assert(NFC_READER_TYPE == RfidHardwareType::PN532,
-              "NFC_READER_TYPE must be RfidHardwareType::PN532 when USE_PN532 is defined.");
+static constexpr RfidHardwareType NFC_READER_TYPE = RfidHardwareType::PN532;
+#elif defined(USE_RC522)
+static constexpr RfidHardwareType NFC_READER_TYPE = RfidHardwareType::RC522;
+#else
+#  error "Define USE_RC522 (default) or USE_PN532 to select an NFC reader."
 #endif
 
 // Hardware pin definitions. These defaults correspond to common ESP32


### PR DESCRIPTION
## Summary
- update the reader selection comment to describe how PlatformIO build flags drive the choice
- derive NFC_READER_TYPE from USE_PN532/USE_RC522 with compile-time errors for invalid combinations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de4bc6fb648320b82a61e89e365661