### PR TITLE
Add warm card detection breathing effect and ensure boot feedback

### DIFF
--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -12,11 +12,12 @@ EffectManager::EffectManager(uint8_t dataPin, uint16_t ledCount, uint8_t default
       _breathingEffect() {}
 
 void EffectManager::begin(unsigned long now) {
+  (void)now;
   _strip.begin();
   _strip.setBrightness(_brightness);
   _strip.setAll(_strip.color(0, 0, 0));
   _strip.apply();
-  setEffect(_solidEffect, now);
+  _activeEffect = nullptr;
 }
 
 void EffectManager::update(unsigned long now) {


### PR DESCRIPTION
## Summary
- ensure the LED strip manager no longer forces a solid color so the Wi-Fi connecting animation is the first effect shown at boot
- introduce a transient "card detected" state that plays a warm, fast breathing animation whenever an NFC tag is read

## Testing
- pio run *(fails: PlatformIO CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de6f07c78c832086af5974873d8158