### PR TITLE
Add boot warm-white state and blink effect for card detection

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -65,15 +65,14 @@ static constexpr uint8_t PN532_SCL_PIN  = 22;  // I²C SCL
 
 // PN532 (SPI) wiring defaults. Define USE_PN532_SPI to activate these pins
 // and the SPI transport in the firmware.
-static constexpr uint8_t PN532_SS_PIN   = 5;   // SPI slave select
-static constexpr uint8_t PN532_SCK_PIN  = 18;  // SPI clock
-static constexpr uint8_t PN532_MOSI_PIN = 23;  // SPI MOSI
-static constexpr uint8_t PN532_MISO_PIN = 19;  // SPI MISO
 
-static constexpr uint8_t LED_PIN     = 2;   // On‑board LED (GPIO2 on most ESP32)
+static constexpr uint8_t PN532_SS_PIN   = 10;  // SPI slave select (CS)
+static constexpr uint8_t PN532_SCK_PIN  = 12;  // SPI clock
+static constexpr uint8_t PN532_MOSI_PIN = 11;  // SPI MOSI
+static constexpr uint8_t PN532_MISO_PIN = 13;  // SPI MISO
 
 // Addressable LED strip configuration (WS2812/NeoPixel)
-static constexpr uint8_t  LED_DATA_PIN           = 12;  // Data in to the strip
+static constexpr uint8_t  LED_DATA_PIN           = 48;  // Data in to the strip
 static constexpr uint16_t LED_COUNT_DEFAULT      = 11;  // Number of pixels in the strip
 static constexpr uint8_t  LED_BRIGHTNESS_DEFAULT = 64;  // 0-255 brightness scaling
 

--- a/include/EffectManager.h
+++ b/include/EffectManager.h
@@ -20,9 +20,12 @@ public:
   void showSolidColor(uint8_t red, uint8_t green, uint8_t blue, unsigned long now);
   void showSnake(uint8_t red, uint8_t green, uint8_t blue, unsigned long now);
   void showBreathing(uint8_t red, uint8_t green, uint8_t blue, unsigned long now);
+  void showBlink(uint8_t red, uint8_t green, uint8_t blue, unsigned long onDurationMs,
+                 unsigned long offDurationMs, uint16_t blinkCount, unsigned long now);
 
   void setBrightness(uint8_t brightness);
   uint8_t brightness() const { return _brightness; }
+  bool isActiveEffectFinished() const;
 
   LedStrip &strip() { return _strip; }
   uint16_t ledCount() const { return _ledCount; }
@@ -30,6 +33,7 @@ public:
   SolidColorEffect &solidEffect() { return _solidEffect; }
   SnakeEffect &snakeEffect() { return _snakeEffect; }
   BreathingEffect &breathingEffect() { return _breathingEffect; }
+  BlinkEffect &blinkEffect() { return _blinkEffect; }
 
 private:
   void activateEffect(Effect &effect, unsigned long now);
@@ -41,5 +45,6 @@ private:
   SolidColorEffect _solidEffect;
   SnakeEffect _snakeEffect;
   BreathingEffect _breathingEffect;
+  BlinkEffect _blinkEffect;
 };
 

--- a/include/Effects.h
+++ b/include/Effects.h
@@ -14,6 +14,7 @@ public:
 
   virtual void begin(unsigned long now) = 0;
   virtual void update(unsigned long now) = 0;
+  virtual bool isFinished() const { return false; }
 
   void attachStrip(LedStrip *strip, uint16_t ledCount);
 
@@ -92,5 +93,32 @@ private:
   uint8_t _blue;
   unsigned long _periodMs;
   unsigned long _startTime;
+};
+
+class BlinkEffect : public Effect {
+public:
+  BlinkEffect();
+
+  void configure(uint8_t red, uint8_t green, uint8_t blue,
+                 unsigned long onDurationMs, unsigned long offDurationMs,
+                 uint16_t blinkCount);
+
+  void begin(unsigned long now) override;
+  void update(unsigned long now) override;
+  bool isFinished() const override { return _finished; }
+
+private:
+  void applyState(bool on);
+
+  uint8_t _red;
+  uint8_t _green;
+  uint8_t _blue;
+  unsigned long _onDurationMs;
+  unsigned long _offDurationMs;
+  uint16_t _blinkCount;
+  uint16_t _completedBlinks;
+  bool _currentStateOn;
+  bool _finished;
+  unsigned long _lastToggle;
 };
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,11 +9,11 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = az-delivery-devkit-v4-pn532
+default_envs = esp32-s3-devkitc-1-pn532
 
 [env]
 platform = espressif32
-board = az-delivery-devkit-v4
+board = esp32-s3-devkitc-1 
 framework = arduino
 
 monitor_speed = 115200
@@ -27,7 +27,7 @@ lib_deps =
 build_flags =
   -DCORE_DEBUG_LEVEL=3
 
-[env:az-delivery-devkit-v4-rc522]
+[env:esp32-s3-devkitc-1-rc522]
 extends = env
 
 lib_deps =
@@ -38,7 +38,7 @@ build_flags =
   ${env.build_flags}
   -DUSE_RC522
 
-[env:az-delivery-devkit-v4-pn532]
+[env:esp32-s3-devkitc-1-pn532]
 extends = env
 
 lib_deps =

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -9,7 +9,8 @@ EffectManager::EffectManager(uint8_t dataPin, uint16_t ledCount, uint8_t default
       _activeEffect(nullptr),
       _solidEffect(),
       _snakeEffect(),
-      _breathingEffect() {}
+      _breathingEffect(),
+      _blinkEffect() {}
 
 void EffectManager::begin(unsigned long now) {
   (void)now;
@@ -48,12 +49,25 @@ void EffectManager::showBreathing(uint8_t red, uint8_t green, uint8_t blue, unsi
   activateEffect(_breathingEffect, now);
 }
 
+void EffectManager::showBlink(uint8_t red, uint8_t green, uint8_t blue, unsigned long onDurationMs,
+                              unsigned long offDurationMs, uint16_t blinkCount, unsigned long now) {
+  _blinkEffect.configure(red, green, blue, onDurationMs, offDurationMs, blinkCount);
+  activateEffect(_blinkEffect, now);
+}
+
 void EffectManager::setBrightness(uint8_t brightness) {
   _brightness = brightness;
   _strip.setBrightness(brightness);
   if (_activeEffect != nullptr) {
     _activeEffect->update(millis());
   }
+}
+
+bool EffectManager::isActiveEffectFinished() const {
+  if (_activeEffect == nullptr) {
+    return true;
+  }
+  return _activeEffect->isFinished();
 }
 
 void EffectManager::activateEffect(Effect &effect, unsigned long now) {


### PR DESCRIPTION
## Summary
- add a dedicated BootWarmWhite visual state that keeps the warm-white breathing animation active during the 10-second startup window before applying Wi-Fi status visuals
- extend the lighting engine with a bounded blink effect and effect manager helper, using it to deliver three rapid green flashes when a card is detected
- track the previous base state and effect completion so transient animations cleanly restore the intended steady-state visual

## Testing
- Not run (PlatformIO CLI not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dfd9d96bc88320adcc78eb7fd1ab9d