### PR TITLE
Add debug action HTTP server and refactor card processing

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -28,6 +28,12 @@ static constexpr const char *const WIFI_PASSWORD = SECRET_WIFI_PASSWORD;
 static constexpr const char *const BACKEND_HOST  = SECRET_BACKEND_HOST;
 static constexpr uint16_t         BACKEND_PORT  = SECRET_BACKEND_PORT;
 
+// Optional debug HTTP server used to trigger firmware actions without
+// physical hardware. Enable it during development to expose
+// troubleshooting endpoints on DEBUG_SERVER_PORT.
+static constexpr bool     ENABLE_DEBUG_ACTIONS = false;
+static constexpr uint16_t DEBUG_SERVER_PORT    = 8081;
+
 // RFID/NFC reader selection. Choose which hardware backend should be
 // compiled into the firmware. Add new enum values if additional reader
 // types are supported in the future. The PlatformIO environment

--- a/include/DebugActionServer.h
+++ b/include/DebugActionServer.h
@@ -1,0 +1,43 @@
+/*
+ * DebugActionServer.h
+ *
+ * Lightweight HTTP server that exposes firmware debug actions via the
+ * ESP32 WebServer. Actions are registered at runtime and can be invoked
+ * with JSON payloads to simulate card reads or preview LED effects
+ * without touching the physical hardware.
+ */
+
+#pragma once
+
+#include <ArduinoJson.h>
+#include <WebServer.h>
+#include <vector>
+
+struct DebugAction {
+  const char *name;
+  const char *description;
+  bool (*handler)(JsonVariantConst payload, String &message);
+};
+
+class DebugActionServer {
+ public:
+  explicit DebugActionServer(uint16_t port);
+
+  void registerAction(const DebugAction &action);
+  void begin();
+  void start();
+  void stop();
+  void loop();
+
+ private:
+  void setupRoutes();
+  void handleListActions();
+  void handleInvokeAction();
+  void sendJson(int statusCode, const JsonDocument &doc);
+
+  WebServer server_;
+  std::vector<DebugAction> actions_;
+  bool routesRegistered_ = false;
+  bool running_ = false;
+};
+

--- a/include/DebugActionServer.h
+++ b/include/DebugActionServer.h
@@ -35,6 +35,7 @@ class DebugActionServer {
   void handleInvokeAction();
   void sendJson(int statusCode, const JsonDocument &doc);
 
+  const uint16_t port_;
   WebServer server_;
   std::vector<DebugAction> actions_;
   bool routesRegistered_ = false;

--- a/src/DebugActionServer.cpp
+++ b/src/DebugActionServer.cpp
@@ -1,0 +1,150 @@
+/*
+ * DebugActionServer.cpp
+ *
+ * Implements a small HTTP server that exposes debug-friendly endpoints
+ * for interacting with firmware behaviour at runtime. This allows
+ * developers to trigger actions over the network instead of relying on
+ * physical inputs.
+ */
+
+#include "DebugActionServer.h"
+
+#include <Arduino.h>
+#include <uri/UriBraces.h>
+
+#include "Config.h"
+
+namespace {
+constexpr size_t kListPayloadCapacity = 768;
+constexpr size_t kActionPayloadCapacity = 512;
+}
+
+DebugActionServer::DebugActionServer(uint16_t port) : server_(port) {}
+
+void DebugActionServer::registerAction(const DebugAction &action) {
+  actions_.push_back(action);
+}
+
+void DebugActionServer::begin() {
+  if (routesRegistered_) {
+    return;
+  }
+
+  setupRoutes();
+  routesRegistered_ = true;
+}
+
+void DebugActionServer::start() {
+  if (!routesRegistered_) {
+    begin();
+  }
+
+  if (running_) {
+    return;
+  }
+
+  server_.begin();
+  running_ = true;
+  Serial.printf("[DebugServer] Started on port %u\n", server_.serverPort());
+}
+
+void DebugActionServer::stop() {
+  if (!running_) {
+    return;
+  }
+
+  server_.stop();
+  running_ = false;
+  Serial.println("[DebugServer] Stopped");
+}
+
+void DebugActionServer::loop() {
+  if (!running_) {
+    return;
+  }
+
+  server_.handleClient();
+}
+
+void DebugActionServer::setupRoutes() {
+  server_.on("/debug/actions", HTTP_GET, [this]() { handleListActions(); });
+
+  server_.on(UriBraces("/debug/actions/{}"), HTTP_POST,
+             [this]() { handleInvokeAction(); });
+
+  server_.onNotFound([this]() {
+    StaticJsonDocument<128> doc;
+    doc["ok"] = false;
+    doc["message"] = "Endpoint not found";
+    sendJson(404, doc);
+  });
+}
+
+void DebugActionServer::handleListActions() {
+  StaticJsonDocument<kListPayloadCapacity> doc;
+  JsonArray actions = doc.createNestedArray("actions");
+
+  for (const DebugAction &action : actions_) {
+    JsonObject entry = actions.createNestedObject();
+    entry["name"] = action.name;
+    entry["description"] = action.description;
+  }
+
+  doc["ok"] = true;
+  sendJson(200, doc);
+}
+
+void DebugActionServer::handleInvokeAction() {
+  if (server_.pathArg(0).isEmpty()) {
+    StaticJsonDocument<128> doc;
+    doc["ok"] = false;
+    doc["message"] = "Missing action name";
+    sendJson(400, doc);
+    return;
+  }
+
+  const String actionName = server_.pathArg(0);
+  const DebugAction *target = nullptr;
+  for (const DebugAction &candidate : actions_) {
+    if (actionName.equalsIgnoreCase(candidate.name)) {
+      target = &candidate;
+      break;
+    }
+  }
+
+  if (target == nullptr) {
+    StaticJsonDocument<128> doc;
+    doc["ok"] = false;
+    doc["message"] = "Unknown action";
+    sendJson(404, doc);
+    return;
+  }
+
+  StaticJsonDocument<kActionPayloadCapacity> payloadDoc;
+  DeserializationError err = deserializeJson(payloadDoc, server_.arg("plain"));
+  if (err) {
+    StaticJsonDocument<160> doc;
+    doc["ok"] = false;
+    doc["message"] = String("Invalid JSON payload: ") + err.c_str();
+    sendJson(400, doc);
+    return;
+  }
+
+  JsonVariantConst payload = payloadDoc.as<JsonVariantConst>();
+  String message;
+  bool ok = target->handler(payload, message);
+
+  StaticJsonDocument<256> response;
+  response["ok"] = ok;
+  response["message"] = message;
+
+  int status = ok ? 200 : 400;
+  sendJson(status, response);
+}
+
+void DebugActionServer::sendJson(int statusCode, const JsonDocument &doc) {
+  String body;
+  serializeJson(doc, body);
+  server_.send(statusCode, "application/json", body);
+}
+


### PR DESCRIPTION
## Summary
- add compile-time switches for the optional debug HTTP server and document them
- introduce a reusable DebugActionServer to expose debug actions over GET/POST endpoints
- refactor card processing logic so debug triggers and NFC reads share the same code paths

## Testing
- not run (firmware)


------
https://chatgpt.com/codex/tasks/task_e_68dffec5de488320a6edb9a8b00d4117