### PR TITLE
Improve LED timing, logging, and breathing visibility

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -74,7 +74,7 @@ static constexpr uint8_t PN532_MISO_PIN = 13;  // SPI MISO
 // Addressable LED strip configuration (WS2812/NeoPixel)
 static constexpr uint8_t  LED_DATA_PIN           = 48;  // Data in to the strip
 static constexpr uint16_t LED_COUNT_DEFAULT      = 11;  // Number of pixels in the strip
-static constexpr uint8_t  LED_BRIGHTNESS_DEFAULT = 64;  // 0-255 brightness scaling
+static constexpr uint8_t  LED_BRIGHTNESS_DEFAULT = 200; // 0-255 brightness scaling
 
 // Debounce interval (ms) to ignore repeated reads of the same card.
 static constexpr unsigned long CARD_DEBOUNCE_MS = 800;

--- a/include/Config.h
+++ b/include/Config.h
@@ -72,7 +72,7 @@ static constexpr uint8_t PN532_MOSI_PIN = 11;  // SPI MOSI
 static constexpr uint8_t PN532_MISO_PIN = 13;  // SPI MISO
 
 // Addressable LED strip configuration (WS2812/NeoPixel)
-static constexpr uint8_t  LED_DATA_PIN           = 48;  // Data in to the strip
+static constexpr uint8_t  LED_DATA_PIN           = 47;  // Data in to the strip
 static constexpr uint16_t LED_COUNT_DEFAULT      = 11;  // Number of pixels in the strip
 static constexpr uint8_t  LED_BRIGHTNESS_DEFAULT = 200; // 0-255 brightness scaling
 

--- a/include/EffectManager.h
+++ b/include/EffectManager.h
@@ -20,6 +20,13 @@ public:
   void showSolidColor(uint8_t red, uint8_t green, uint8_t blue, unsigned long now);
   void showSnake(uint8_t red, uint8_t green, uint8_t blue, unsigned long now);
   void showBreathing(uint8_t red, uint8_t green, uint8_t blue, unsigned long now);
+  void showComet(uint8_t red, uint8_t green, uint8_t blue,
+                 float firstTailFactor, float secondTailFactor,
+                 CometEffect::Direction direction,
+                 unsigned long intervalMs, unsigned long now);
+  void showFade(uint8_t startRed, uint8_t startGreen, uint8_t startBlue,
+                uint8_t endRed, uint8_t endGreen, uint8_t endBlue,
+                unsigned long durationMs, unsigned long now);
 
   void setBrightness(uint8_t brightness);
   uint8_t brightness() const { return _brightness; }
@@ -30,6 +37,8 @@ public:
   SolidColorEffect &solidEffect() { return _solidEffect; }
   SnakeEffect &snakeEffect() { return _snakeEffect; }
   BreathingEffect &breathingEffect() { return _breathingEffect; }
+  CometEffect &cometEffect() { return _cometEffect; }
+  FadeEffect &fadeEffect() { return _fadeEffect; }
 
 private:
   void activateEffect(Effect &effect, unsigned long now);
@@ -41,5 +50,7 @@ private:
   SolidColorEffect _solidEffect;
   SnakeEffect _snakeEffect;
   BreathingEffect _breathingEffect;
+  CometEffect _cometEffect;
+  FadeEffect _fadeEffect;
 };
 

--- a/include/Effects.h
+++ b/include/Effects.h
@@ -74,6 +74,65 @@ private:
   uint16_t _position;
 };
 
+class CometEffect : public Effect {
+public:
+  enum class Direction { Clockwise, CounterClockwise };
+
+  CometEffect(uint8_t red = 255, uint8_t green = 255, uint8_t blue = 255,
+              float firstTailFactor = 0.5f, float secondTailFactor = 0.2f,
+              unsigned long intervalMs = 50UL,
+              Direction direction = Direction::Clockwise);
+
+  void setColor(uint8_t red, uint8_t green, uint8_t blue);
+  void setTailFactors(float firstTailFactor, float secondTailFactor);
+  void setInterval(unsigned long intervalMs);
+  void setDirection(Direction direction);
+
+  void begin(unsigned long now) override;
+  void update(unsigned long now) override;
+
+private:
+  void draw();
+  uint32_t scaledColor(float factor);
+
+  uint8_t _red;
+  uint8_t _green;
+  uint8_t _blue;
+  float _firstTailFactor;
+  float _secondTailFactor;
+  unsigned long _intervalMs;
+  unsigned long _lastStep;
+  uint16_t _position;
+  Direction _direction;
+};
+
+class FadeEffect : public Effect {
+public:
+  FadeEffect(uint8_t startRed = 255, uint8_t startGreen = 0, uint8_t startBlue = 0,
+             uint8_t endRed = 0, uint8_t endGreen = 0, uint8_t endBlue = 0,
+             unsigned long durationMs = 300UL);
+
+  void setColors(uint8_t startRed, uint8_t startGreen, uint8_t startBlue,
+                 uint8_t endRed, uint8_t endGreen, uint8_t endBlue);
+  void setDuration(unsigned long durationMs);
+
+  void begin(unsigned long now) override;
+  void update(unsigned long now) override;
+
+private:
+  void apply(float progress);
+
+  uint8_t _startRed;
+  uint8_t _startGreen;
+  uint8_t _startBlue;
+  uint8_t _endRed;
+  uint8_t _endGreen;
+  uint8_t _endBlue;
+  unsigned long _durationMs;
+  unsigned long _startTime;
+  bool _complete;
+};
+
 class BreathingEffect : public Effect {
 public:
   BreathingEffect(uint8_t red = 0, uint8_t green = 0, uint8_t blue = 255, unsigned long periodMs = 2000UL);

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -18,6 +18,8 @@ void EffectManager::begin(unsigned long now) {
   _strip.setAll(_strip.color(0, 0, 0));
   _strip.apply();
   _activeEffect = nullptr;
+  Serial.printf("[Effects] LED strip initialised with %u LEDs at brightness %u\n",
+                _ledCount, _brightness);
 }
 
 void EffectManager::update(unsigned long now) {
@@ -33,6 +35,7 @@ void EffectManager::setEffect(Effect &effect, unsigned long now) {
 
 void EffectManager::showSolidColor(uint8_t red, uint8_t green, uint8_t blue, unsigned long now) {
   _solidEffect.setColor(red, green, blue);
+  Serial.printf("[Effects] Activating SolidColor (R:%u G:%u B:%u)\n", red, green, blue);
   activateEffect(_solidEffect, now);
 }
 
@@ -40,11 +43,15 @@ void EffectManager::showSnake(uint8_t red, uint8_t green, uint8_t blue, unsigned
   _snakeEffect.setHeadColor(red, green, blue);
   _snakeEffect.setTailColor(red / 6, green / 6, blue / 6);
   _snakeEffect.setBackgroundColor(0, 0, 0);
+  Serial.printf("[Effects] Activating Snake (head:%u,%u,%u) at %lums\n",
+                red, green, blue, now);
   activateEffect(_snakeEffect, now);
 }
 
 void EffectManager::showBreathing(uint8_t red, uint8_t green, uint8_t blue, unsigned long now) {
   _breathingEffect.setColor(red, green, blue);
+  Serial.printf("[Effects] Activating Breathing (R:%u G:%u B:%u) at %lums\n",
+                red, green, blue, now);
   activateEffect(_breathingEffect, now);
 }
 
@@ -52,6 +59,7 @@ void EffectManager::setBrightness(uint8_t brightness) {
   _brightness = brightness;
   _strip.setBrightness(brightness);
   if (_activeEffect != nullptr) {
+    Serial.printf("[Effects] Brightness changed to %u - forcing immediate update\n", brightness);
     _activeEffect->update(millis());
   }
 }
@@ -59,6 +67,7 @@ void EffectManager::setBrightness(uint8_t brightness) {
 void EffectManager::activateEffect(Effect &effect, unsigned long now) {
   effect.attachStrip(&_strip, _ledCount);
   _activeEffect = &effect;
+  Serial.printf("[Effects] Effect initialised at %lums\n", now);
   _activeEffect->begin(now);
   _activeEffect->update(now);
 }

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -9,7 +9,9 @@ EffectManager::EffectManager(uint8_t dataPin, uint16_t ledCount, uint8_t default
       _activeEffect(nullptr),
       _solidEffect(),
       _snakeEffect(),
-      _breathingEffect() {}
+      _breathingEffect(),
+      _cometEffect(),
+      _fadeEffect() {}
 
 void EffectManager::begin(unsigned long now) {
   (void)now;
@@ -53,6 +55,41 @@ void EffectManager::showBreathing(uint8_t red, uint8_t green, uint8_t blue, unsi
   Serial.printf("[Effects] Activating Breathing (R:%u G:%u B:%u) at %lums\n",
                 red, green, blue, now);
   activateEffect(_breathingEffect, now);
+}
+
+void EffectManager::showComet(uint8_t red, uint8_t green, uint8_t blue,
+                              float firstTailFactor, float secondTailFactor,
+                              CometEffect::Direction direction,
+                              unsigned long intervalMs, unsigned long now) {
+  _cometEffect.setColor(red, green, blue);
+  _cometEffect.setTailFactors(firstTailFactor, secondTailFactor);
+  _cometEffect.setDirection(direction);
+  _cometEffect.setInterval(intervalMs);
+  Serial.printf("[Effects] Activating Comet (R:%u G:%u B:%u, tail %.2f/%.2f, %s, %lums)\n",
+                red,
+                green,
+                blue,
+                firstTailFactor,
+                secondTailFactor,
+                direction == CometEffect::Direction::Clockwise ? "CW" : "CCW",
+                intervalMs);
+  activateEffect(_cometEffect, now);
+}
+
+void EffectManager::showFade(uint8_t startRed, uint8_t startGreen, uint8_t startBlue,
+                             uint8_t endRed, uint8_t endGreen, uint8_t endBlue,
+                             unsigned long durationMs, unsigned long now) {
+  _fadeEffect.setColors(startRed, startGreen, startBlue, endRed, endGreen, endBlue);
+  _fadeEffect.setDuration(durationMs);
+  Serial.printf("[Effects] Activating Fade (from %u,%u,%u to %u,%u,%u over %lums)\n",
+                startRed,
+                startGreen,
+                startBlue,
+                endRed,
+                endGreen,
+                endBlue,
+                durationMs);
+  activateEffect(_fadeEffect, now);
 }
 
 void EffectManager::setBrightness(uint8_t brightness) {

--- a/src/Effects.cpp
+++ b/src/Effects.cpp
@@ -126,9 +126,14 @@ void BreathingEffect::setPeriod(unsigned long periodMs) {
   _periodMs = periodMs == 0 ? 1 : periodMs;
 }
 
+namespace {
+constexpr float kBreathingMinIntensity = 0.1f;
+constexpr float kBreathingRange = 1.0f - kBreathingMinIntensity;
+}
+
 void BreathingEffect::begin(unsigned long now) {
   _startTime = now;
-  applyIntensity(0.0f);
+  applyIntensity(kBreathingMinIntensity);
 }
 
 void BreathingEffect::update(unsigned long now) {
@@ -136,7 +141,8 @@ void BreathingEffect::update(unsigned long now) {
   unsigned long period = _periodMs == 0 ? 1 : _periodMs;
   float phase = static_cast<float>(elapsed % period) / static_cast<float>(period);
   float intensity = 0.5f * (1.0f - cosf(phase * 2.0f * static_cast<float>(M_PI)));
-  applyIntensity(intensity);
+  float adjustedIntensity = kBreathingMinIntensity + (kBreathingRange * intensity);
+  applyIntensity(adjustedIntensity);
 }
 
 void BreathingEffect::applyIntensity(float intensity) {

--- a/src/Effects.cpp
+++ b/src/Effects.cpp
@@ -113,6 +113,200 @@ void SnakeEffect::draw() {
   strip().apply();
 }
 
+CometEffect::CometEffect(uint8_t red, uint8_t green, uint8_t blue,
+                         float firstTailFactor, float secondTailFactor,
+                         unsigned long intervalMs, Direction direction)
+    : _red(red),
+      _green(green),
+      _blue(blue),
+      _firstTailFactor(firstTailFactor),
+      _secondTailFactor(secondTailFactor),
+      _intervalMs(intervalMs),
+      _lastStep(0),
+      _position(0),
+      _direction(direction) {}
+
+void CometEffect::setColor(uint8_t red, uint8_t green, uint8_t blue) {
+  _red = red;
+  _green = green;
+  _blue = blue;
+}
+
+void CometEffect::setTailFactors(float firstTailFactor, float secondTailFactor) {
+  _firstTailFactor = firstTailFactor;
+  _secondTailFactor = secondTailFactor;
+}
+
+void CometEffect::setInterval(unsigned long intervalMs) {
+  _intervalMs = intervalMs == 0 ? 1 : intervalMs;
+}
+
+void CometEffect::setDirection(Direction direction) {
+  _direction = direction;
+}
+
+void CometEffect::begin(unsigned long now) {
+  _position = 0;
+  _lastStep = now;
+  draw();
+}
+
+void CometEffect::update(unsigned long now) {
+  if (ledCount() == 0) {
+    return;
+  }
+
+  if (now - _lastStep < _intervalMs) {
+    return;
+  }
+
+  _lastStep = now;
+  if (_direction == Direction::Clockwise) {
+    _position = (_position + 1) % ledCount();
+  } else {
+    _position = (_position + ledCount() - 1) % ledCount();
+  }
+  draw();
+}
+
+void CometEffect::draw() {
+  strip().setAll(strip().color(0, 0, 0));
+
+  if (ledCount() == 0) {
+    strip().apply();
+    return;
+  }
+
+  uint32_t head = strip().color(_red, _green, _blue);
+  strip().setPixel(_position, head);
+
+  if (ledCount() > 1) {
+    uint16_t firstTailIndex = 0;
+    if (_direction == Direction::Clockwise) {
+      firstTailIndex = (_position + ledCount() - 1) % ledCount();
+    } else {
+      firstTailIndex = (_position + 1) % ledCount();
+    }
+    strip().setPixel(firstTailIndex, scaledColor(_firstTailFactor));
+  }
+
+  if (ledCount() > 2) {
+    uint16_t secondTailIndex = 0;
+    if (_direction == Direction::Clockwise) {
+      secondTailIndex = (_position + ledCount() - 2) % ledCount();
+    } else {
+      secondTailIndex = (_position + 2) % ledCount();
+    }
+    strip().setPixel(secondTailIndex, scaledColor(_secondTailFactor));
+  }
+
+  strip().apply();
+}
+
+uint32_t CometEffect::scaledColor(float factor) {
+  float clamped = factor;
+  if (clamped < 0.0f) {
+    clamped = 0.0f;
+  } else if (clamped > 1.0f) {
+    clamped = 1.0f;
+  }
+
+  auto scale = [clamped](uint8_t component) -> uint8_t {
+    float value = static_cast<float>(component) * clamped;
+    if (value <= 0.0f) {
+      return 0;
+    }
+    if (value >= 255.0f) {
+      return 255;
+    }
+    return static_cast<uint8_t>(value + 0.5f);
+  };
+
+  return strip().color(scale(_red), scale(_green), scale(_blue));
+}
+
+FadeEffect::FadeEffect(uint8_t startRed, uint8_t startGreen, uint8_t startBlue,
+                       uint8_t endRed, uint8_t endGreen, uint8_t endBlue,
+                       unsigned long durationMs)
+    : _startRed(startRed),
+      _startGreen(startGreen),
+      _startBlue(startBlue),
+      _endRed(endRed),
+      _endGreen(endGreen),
+      _endBlue(endBlue),
+      _durationMs(durationMs),
+      _startTime(0),
+      _complete(false) {}
+
+void FadeEffect::setColors(uint8_t startRed, uint8_t startGreen, uint8_t startBlue,
+                           uint8_t endRed, uint8_t endGreen, uint8_t endBlue) {
+  _startRed = startRed;
+  _startGreen = startGreen;
+  _startBlue = startBlue;
+  _endRed = endRed;
+  _endGreen = endGreen;
+  _endBlue = endBlue;
+}
+
+void FadeEffect::setDuration(unsigned long durationMs) {
+  _durationMs = durationMs;
+}
+
+void FadeEffect::begin(unsigned long now) {
+  _startTime = now;
+  _complete = false;
+  apply(0.0f);
+}
+
+void FadeEffect::update(unsigned long now) {
+  if (_complete && _durationMs != 0) {
+    return;
+  }
+
+  if (_durationMs == 0) {
+    apply(1.0f);
+    _complete = true;
+    return;
+  }
+
+  unsigned long elapsed = now - _startTime;
+  float progress = static_cast<float>(elapsed) / static_cast<float>(_durationMs);
+  if (progress >= 1.0f) {
+    apply(1.0f);
+    _complete = true;
+  } else {
+    apply(progress);
+  }
+}
+
+void FadeEffect::apply(float progress) {
+  float clamped = progress;
+  if (clamped < 0.0f) {
+    clamped = 0.0f;
+  } else if (clamped > 1.0f) {
+    clamped = 1.0f;
+  }
+
+  auto lerp = [clamped](uint8_t start, uint8_t end) -> uint8_t {
+    float value = static_cast<float>(start) + (static_cast<float>(end) - static_cast<float>(start)) * clamped;
+    if (value <= 0.0f) {
+      return 0;
+    }
+    if (value >= 255.0f) {
+      return 255;
+    }
+    return static_cast<uint8_t>(value + 0.5f);
+  };
+
+  uint8_t red = lerp(_startRed, _endRed);
+  uint8_t green = lerp(_startGreen, _endGreen);
+  uint8_t blue = lerp(_startBlue, _endBlue);
+
+  uint32_t colorValue = strip().color(red, green, blue);
+  strip().setAll(colorValue);
+  strip().apply();
+}
+
 BreathingEffect::BreathingEffect(uint8_t red, uint8_t green, uint8_t blue, unsigned long periodMs)
     : _red(red), _green(green), _blue(blue), _periodMs(periodMs), _startTime(0) {}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,7 @@ enum class VisualState {
 static VisualState baseVisualState = VisualState::WifiConnecting;
 static VisualState currentVisualState = VisualState::WifiConnecting;
 static unsigned long visualStateChangedAt = 0;
+static bool visualStateInitialized = false;
 
 static const char *visualStateName(VisualState state) {
   switch (state) {
@@ -161,12 +162,16 @@ static void applyVisualState(VisualState state, unsigned long now) {
 }
 
 static void setVisualState(VisualState state, unsigned long now) {
+  if (visualStateInitialized && currentVisualState == state) {
+    return;
+  }
   if (currentVisualState != state) {
     Serial.printf("[State] Transitioning from %s to %s at %lums\n",
                   visualStateName(currentVisualState), visualStateName(state), now);
   }
   currentVisualState = state;
   visualStateChangedAt = now;
+  visualStateInitialized = true;
   applyVisualState(state, now);
 }
 


### PR DESCRIPTION
## Summary
- extend transient LED effect duration and log all visual state transitions for easier debugging
- add detailed effect activation diagnostics in EffectManager so solid, snake, and breathing modes are identifiable
- start the breathing effect at a minimum brightness to keep LEDs visible at the beginning of each cycle

## Testing
- `pio run` *(fails: command not found: pio)*

------
https://chatgpt.com/codex/tasks/task_e_68e0087e22a48320ae7ff460b0716672