### PR TITLE
Reduce PN532 polling stalls during card flow

### DIFF
--- a/src/RfidReader.cpp
+++ b/src/RfidReader.cpp
@@ -33,6 +33,10 @@
 
 namespace {
 
+#if defined(USE_PN532)
+static constexpr uint16_t PN532_POLL_TIMEOUT_MS = 150;
+#endif
+
 String bytesToHexString(const uint8_t *buffer, size_t length) {
   String uidHex;
   uidHex.reserve(length * 2);
@@ -204,7 +208,8 @@ bool begin() override {
     std::array<uint8_t, 10> uid{};
     uint8_t uidLength = 0;
 
-    bool success = _pn532.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid.data(), &uidLength, 1000);
+    bool success =
+        _pn532.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid.data(), &uidLength, PN532_POLL_TIMEOUT_MS);
     if (!success) {
       return false;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,9 +32,13 @@ static VisualState currentVisualState = VisualState::WifiConnecting;
 static unsigned long visualStateChangedAt = 0;
 static constexpr unsigned long TRANSIENT_EFFECT_DURATION_MS = 2500;
 
-static bool isTransientState(VisualState state) {
+static bool isCardFlowState(VisualState state) {
   return state == VisualState::CardDetected || state == VisualState::BackendSuccess ||
          state == VisualState::BackendError;
+}
+
+static bool isTransientState(VisualState state) {
+  return isCardFlowState(state);
 }
 
 static void applyVisualState(VisualState state, unsigned long now) {
@@ -187,7 +191,10 @@ void loop() {
 
   // Try to read a card
   String uid;
-  bool cardRead = rfid.readCard(uid);
+  bool cardRead = false;
+  if (!isCardFlowState(currentVisualState)) {
+    cardRead = rfid.readCard(uid);
+  }
   
   if (cardRead) {
     Serial.println("*** CARD DETECTED ***");


### PR DESCRIPTION
## Summary
- skip RFID polling while card-flow animations are active to let LED timings update smoothly
- shorten the PN532 passive target timeout so idle polling no longer blocks the main loop for a full second

## Testing
- not run (hardware-dependent)

------
https://chatgpt.com/codex/tasks/task_e_68e2bf7a4e588320ac3e2a184f4e3f7f