### PR TITLE
Handle backend requests asynchronously

### DIFF
--- a/include/BackendClient.h
+++ b/include/BackendClient.h
@@ -21,4 +21,34 @@ public:
    * returns false and logs the error via Serial.
    */
   bool postPlay(const String &cardUid);
+
+  /**
+   * Start the backend request on a background FreeRTOS task. Returns
+   * true if the task was created successfully. The caller can poll
+   * {@link pollResult} to obtain the outcome once the request
+   * completes.
+   */
+  bool beginPostPlayAsync(const String &cardUid);
+
+  /**
+   * Returns true while a background request is still running.
+   */
+  bool isBusy() const;
+
+  /**
+   * Poll for the result of the most recent asynchronous request. When
+   * the request completes, this method stores the success flag in
+   * `outSuccess` and returns true. Otherwise it returns false to
+   * indicate that the operation is still in progress.
+   */
+  bool pollResult(bool &outSuccess);
+
+private:
+  bool performPostPlay(const String &cardUid);
+  static void requestTask(void *param);
+
+  volatile bool requestInProgress = false;
+  volatile bool requestCompleted = false;
+  volatile bool lastRequestSuccess = false;
+  String pendingUid;
 };


### PR DESCRIPTION
## Summary
- add asynchronous helpers in `BackendClient` to run backend calls on a background FreeRTOS task
- update the main loop to track pending backend requests and keep driving effects while waiting
- introduce a dedicated card scanning visual state so LEDs stay responsive during backend work

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2bf79bf308320af490466f63aae4b