### PR TITLE
Refactor Wi-Fi connection handling

### DIFF
--- a/include/WifiManager.h
+++ b/include/WifiManager.h
@@ -33,9 +33,16 @@ public:
 
   /**
    * Returns true if the ESP is currently connected to Wi‑Fi.
-   */
+  */
   bool isConnected() const;
 
 private:
-  unsigned long _lastCheckMillis = 0;
+  enum class ConnectionState { Idle, Connecting, Cooldown };
+
+  void startConnectionAttempt(unsigned long now);
+
+  ConnectionState _state = ConnectionState::Idle;
+  unsigned long _stateChangedAt = 0;
+  uint8_t _attemptsThisCycle = 0;
+  bool _hasLoggedConnected = false;
 };

--- a/src/WifiManager.cpp
+++ b/src/WifiManager.cpp
@@ -7,42 +7,98 @@
 
 #include "WifiManager.h"
 
+namespace {
+constexpr bool hasRetryLimit() {
+  return MAX_WIFI_RETRIES > 0;
+}
+}
+
 bool WifiManager::begin() {
   WiFi.mode(WIFI_STA);
-  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  Serial.println("Connecting to Wi-Fi...");
 
-  Serial.print("Connecting to Wi-Fi...\n");
-  uint8_t retries = 0;
-  while (WiFi.status() != WL_CONNECTED && retries < MAX_WIFI_RETRIES) {
-    delay(WIFI_RETRY_DELAY_MS);
-    Serial.print('.');
-    retries++;
-  }
+  _attemptsThisCycle = 0;
+  _state = ConnectionState::Idle;
+  _stateChangedAt = millis();
+  _hasLoggedConnected = false;
 
-  bool connected = (WiFi.status() == WL_CONNECTED);
-  if (connected) {
-    Serial.printf("\nConnected to %s, IP: %s\n", WIFI_SSID, WiFi.localIP().toString().c_str());
-  } else {
-    Serial.println("\nFailed to connect to Wi-Fi");
-  }
-  return connected;
+  startConnectionAttempt(_stateChangedAt);
+  return WiFi.status() == WL_CONNECTED;
 }
 
 void WifiManager::loop() {
-  // Only check every 5 seconds to reduce overhead
-  if (millis() - _lastCheckMillis < 5000UL) {
+  unsigned long now = millis();
+  wl_status_t status = WiFi.status();
+
+  if (status == WL_CONNECTED) {
+    if (!_hasLoggedConnected) {
+      Serial.printf("[WiFi] Connected to %s, IP: %s\n",
+                    WIFI_SSID,
+                    WiFi.localIP().toString().c_str());
+      _hasLoggedConnected = true;
+    }
+    _state = ConnectionState::Idle;
+    _stateChangedAt = now;
+    _attemptsThisCycle = 0;
     return;
   }
-  _lastCheckMillis = millis();
 
-  wl_status_t status = WiFi.status();
-  if (status != WL_CONNECTED) {
-    Serial.println("Wi-Fi disconnected, attempting reconnect...");
-    WiFi.disconnect();
-    WiFi.reconnect();
+  _hasLoggedConnected = false;
+
+  switch (_state) {
+    case ConnectionState::Idle:
+      if (_attemptsThisCycle == 0 || now - _stateChangedAt >= WIFI_RETRY_DELAY_MS) {
+        if (!hasRetryLimit() || _attemptsThisCycle < MAX_WIFI_RETRIES) {
+          startConnectionAttempt(now);
+        } else {
+          Serial.println("[WiFi] Maximum retries reached. Backing off before retrying.");
+          _state = ConnectionState::Cooldown;
+          _stateChangedAt = now;
+        }
+      }
+      break;
+
+    case ConnectionState::Connecting:
+      if (now - _stateChangedAt >= WIFI_RETRY_DELAY_MS) {
+        if (!hasRetryLimit() || _attemptsThisCycle < MAX_WIFI_RETRIES) {
+          Serial.println("[WiFi] Connection timed out, retrying...");
+          startConnectionAttempt(now);
+        } else {
+          Serial.println("[WiFi] Maximum retries reached. Backing off before retrying.");
+          _state = ConnectionState::Cooldown;
+          _stateChangedAt = now;
+        }
+      }
+      break;
+
+    case ConnectionState::Cooldown:
+      if (now - _stateChangedAt >= WIFI_RETRY_DELAY_MS) {
+        _attemptsThisCycle = 0;
+        startConnectionAttempt(now);
+      }
+      break;
   }
 }
 
 bool WifiManager::isConnected() const {
   return WiFi.status() == WL_CONNECTED;
+}
+
+void WifiManager::startConnectionAttempt(unsigned long now) {
+  if (_attemptsThisCycle > 0) {
+    WiFi.disconnect();
+  }
+
+  uint8_t attemptNumber = _attemptsThisCycle + 1;
+  if (hasRetryLimit()) {
+    Serial.printf("[WiFi] Attempt %u/%u to connect...\n", attemptNumber, MAX_WIFI_RETRIES);
+  } else {
+    Serial.printf("[WiFi] Attempt %u to connect...\n", attemptNumber);
+  }
+
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+
+  _state = ConnectionState::Connecting;
+  _stateChangedAt = now;
+  _attemptsThisCycle++;
 }


### PR DESCRIPTION
## Summary
- replace the blocking Serial warm-up delay with a non-blocking readiness poll
- refactor WifiManager to launch asynchronous connection attempts driven by millis()
- update setup/loop logic to reflect the asynchronous Wi-Fi state and start debug tools on connect

## Testing
- pio run *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b68b01588320b5f2898b438a4b50