### PR TITLE
Refactor PN532 initialization to avoid blocking delays

### DIFF
--- a/include/RfidReader.h
+++ b/include/RfidReader.h
@@ -17,6 +17,8 @@ public:
   virtual ~IRfidBackend() = default;
   virtual bool begin() = 0;
   virtual bool readCard(String &uidHex) = 0;
+  virtual bool isReady() const = 0;
+  virtual bool hasFailed() const = 0;
 };
 
 class RfidReader {
@@ -36,4 +38,6 @@ public:
 
 private:
   std::unique_ptr<IRfidBackend> _backend;
+  bool                         _backendReady = false;
+  bool                         _backendFailed = false;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -609,7 +609,7 @@ void setup() {
   // Initialise NFC reader
   Serial.println("Initializing NFC reader...");
   rfid.begin();
-  Serial.println("NFC reader initialized");
+  Serial.println("NFC reader initialization in progress");
 
 #if ENABLE_DEBUG_ACTIONS
   debugServer.registerAction({"set_visual_state",
@@ -639,6 +639,8 @@ void loop() {
   wifi.loop();
 
   unsigned long now = millis();
+
+  rfid.begin();
 
   bool isConnected = wifi.isConnected();
   if (isConnected && !wifiPreviouslyConnected) {


### PR DESCRIPTION
## Summary
- replace PN532 backend delays with a millis()-driven state machine that preserves retry behaviour without blocking
- add readiness/failure reporting to RFID backends and make the reader initialise asynchronously over successive begin() calls
- call the reader initialisation from loop() so setup can return quickly while hardware continues to start up

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e3c62a917c83209982125e5cac8fdc