### PR TITLE
Add OTA firmware update checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ MusicBee turns NFC cards into kid-friendly controls for a Google Nest or other n
 - Tap-to-play card detection with debounce, backend notification, and serial logging.
 - Supports MFRC522 (SPI) and PN532 (I²C or SPI) NFC modules selected at compile time.
 - Wi-Fi connection management with automatic retry and optional mDNS discovery for `.local` backends.
+- Automatic OTA firmware checks on boot and every 24 hours with manifest-driven updates.
 - RGB status LED with success, error, and connectivity feedback patterns.
 - Optional debug HTTP server for remote visual testing and simulated card scans.
 
@@ -72,7 +73,7 @@ MusicBee turns NFC cards into kid-friendly controls for a Google Nest or other n
 ## Runtime Behavior
 
 * On boot the firmware initializes the RGB LED, connects to Wi-Fi, announces the optional `nfc-jukebox` mDNS name, and runs a brief LED self-test.
-* During the main loop it keeps Wi-Fi alive, debounces repeated card reads, and sends accepted UIDs to the backend API at `/api/v1/cards/{uid}/play`.
+* During the main loop it keeps Wi-Fi alive, debounces repeated card reads, checks the OTA manifest every 24 hours, and sends accepted UIDs to the backend API at `/api/v1/cards/{uid}/play`.
 * LED feedback indicates state: green blink for success, red for errors, blue for connection attempts.
 * Backend responses and errors are printed over serial to help with troubleshooting.
 

--- a/include/BackendClient.h
+++ b/include/BackendClient.h
@@ -43,6 +43,14 @@ public:
    */
   bool pollResult(bool &outSuccess);
 
+  /**
+   * Resolve a hostname, performing an mDNS lookup when the provided
+   * host ends with `.local`. The resolved hostname (IP string or the
+   * original host if no lookup was necessary) is written to
+   * `resolvedOut`.
+   */
+  static bool resolveHostname(const String &host, String &resolvedOut);
+
 private:
   bool performPostPlay(const String &cardUid);
   static void requestTask(void *param);

--- a/include/Config.h
+++ b/include/Config.h
@@ -90,5 +90,12 @@ static constexpr unsigned long CARD_DEBOUNCE_MS = 800;
 static constexpr unsigned long WIFI_RETRY_DELAY_MS = 2000;
 static constexpr uint8_t       MAX_WIFI_RETRIES     = 20;
 
+// Firmware versioning and OTA configuration.
+static constexpr const char *const CURRENT_FIRMWARE_VERSION = "1.0.0";
+static constexpr const char *const OTA_MANIFEST_PATH        = "/firmware/manifest.json";
+static constexpr unsigned long     OTA_CHECK_INTERVAL_MS    =
+    24UL * 60UL * 60UL * 1000UL;  // 24 hours
+static constexpr unsigned long OTA_HTTP_TIMEOUT_MS = 10000;
+
 
 // Legacy discrete RGB LED configuration removed; use the NeoPixel strip instead.

--- a/include/Config.h
+++ b/include/Config.h
@@ -27,6 +27,8 @@ static constexpr const char *const WIFI_PASSWORD = SECRET_WIFI_PASSWORD;
 // update secrets.h so they remain outside of source control.
 static constexpr const char *const BACKEND_HOST  = SECRET_BACKEND_HOST;
 static constexpr uint16_t         BACKEND_PORT  = SECRET_BACKEND_PORT;
+// Base prefix for REST endpoints exposed by the backend service.
+static constexpr const char *const BACKEND_API_PREFIX = "/api/v1";
 
 // Optional debug HTTP server used to trigger firmware actions without
 // physical hardware. Enable it during development to expose
@@ -92,6 +94,7 @@ static constexpr uint8_t       MAX_WIFI_RETRIES     = 20;
 
 // Firmware versioning and OTA configuration.
 static constexpr const char *const CURRENT_FIRMWARE_VERSION = "1.0.0";
+// OTA manifest endpoint relative to BACKEND_API_PREFIX.
 static constexpr const char *const OTA_MANIFEST_PATH        = "/firmware/manifest.json";
 static constexpr unsigned long     OTA_CHECK_INTERVAL_MS    =
     24UL * 60UL * 60UL * 1000UL;  // 24 hours

--- a/include/OtaUpdater.h
+++ b/include/OtaUpdater.h
@@ -22,7 +22,6 @@ private:
   void checkForUpdates();
   bool fetchManifest(String &versionOut, String &firmwareUrlOut,
                      String &resolvedHostOut);
-  bool resolveHost(const String &host, String &resolvedOut);
   bool downloadAndInstall(const String &url, const String &manifestHost,
                           const String &newVersion);
   static int compareVersions(const String &lhs, const String &rhs);

--- a/include/OtaUpdater.h
+++ b/include/OtaUpdater.h
@@ -1,0 +1,31 @@
+/*
+ * OtaUpdater.h
+ *
+ * Declares a helper responsible for periodically checking a remote
+ * manifest for new firmware versions and applying OTA updates when
+ * available.
+ */
+
+#pragma once
+
+#include <Arduino.h>
+
+class OtaUpdater {
+public:
+  OtaUpdater();
+
+  void loop(unsigned long now, bool wifiConnected);
+
+private:
+  bool shouldCheck(unsigned long now) const;
+  void scheduleAfterAttempt(unsigned long now);
+  void checkForUpdates();
+  bool fetchManifest(String &versionOut, String &firmwareUrlOut);
+  bool resolveHost(String &hostOut);
+  bool downloadAndInstall(const String &url, const String &newVersion);
+  static int compareVersions(const String &lhs, const String &rhs);
+
+  unsigned long _lastCheckAt;
+  bool _checkedSinceBoot;
+};
+

--- a/include/OtaUpdater.h
+++ b/include/OtaUpdater.h
@@ -20,9 +20,11 @@ private:
   bool shouldCheck(unsigned long now) const;
   void scheduleAfterAttempt(unsigned long now);
   void checkForUpdates();
-  bool fetchManifest(String &versionOut, String &firmwareUrlOut);
-  bool resolveHost(String &hostOut);
-  bool downloadAndInstall(const String &url, const String &newVersion);
+  bool fetchManifest(String &versionOut, String &firmwareUrlOut,
+                     String &resolvedHostOut);
+  bool resolveHost(const String &host, String &resolvedOut);
+  bool downloadAndInstall(const String &url, const String &manifestHost,
+                          const String &newVersion);
   static int compareVersions(const String &lhs, const String &rhs);
 
   unsigned long _lastCheckAt;

--- a/src/DebugActionServer.cpp
+++ b/src/DebugActionServer.cpp
@@ -74,7 +74,7 @@ void DebugActionServer::setupRoutes() {
              [this]() { handleInvokeAction(); });
 
   server_.onNotFound([this]() {
-    DynamicJsonDocument doc(128);
+  JsonDocument doc;
     doc["ok"] = false;
     doc["message"] = "Endpoint not found";
     sendJson(404, doc);

--- a/src/OtaUpdater.cpp
+++ b/src/OtaUpdater.cpp
@@ -106,7 +106,6 @@ bool OtaUpdater::fetchManifest(String &versionOut, String &firmwareUrlOut,
   }
 
   JsonDocument doc;
-  doc.reserve(512);
   DeserializationError err = deserializeJson(doc, responseBody);
   if (err) {
     Serial.printf("[OTA] Failed to parse manifest JSON: %s\n",

--- a/src/OtaUpdater.cpp
+++ b/src/OtaUpdater.cpp
@@ -104,7 +104,8 @@ bool OtaUpdater::fetchManifest(String &versionOut, String &firmwareUrlOut,
     return false;
   }
 
-  JsonDocument doc(512);
+  JsonDocument doc;
+  doc.reserve(512);
   DeserializationError err = deserializeJson(doc, responseBody);
   if (err) {
     Serial.printf("[OTA] Failed to parse manifest JSON: %s\n",

--- a/src/OtaUpdater.cpp
+++ b/src/OtaUpdater.cpp
@@ -1,0 +1,229 @@
+/*
+ * OtaUpdater.cpp
+ *
+ * Implements periodic OTA update checks against a remote manifest.
+ */
+
+#include "OtaUpdater.h"
+
+#include <ArduinoJson.h>
+#include <ESPmDNS.h>
+#include <HttpClient.h>
+#include <HTTPClient.h>
+#include <Update.h>
+#include <WiFiClient.h>
+
+#include "Config.h"
+
+namespace {
+constexpr unsigned long kDefaultManifestTimeoutMs = 10000;
+}
+
+OtaUpdater::OtaUpdater() : _lastCheckAt(0), _checkedSinceBoot(false) {}
+
+void OtaUpdater::loop(unsigned long now, bool wifiConnected) {
+  if (!wifiConnected) {
+    return;
+  }
+  if (!shouldCheck(now)) {
+    return;
+  }
+  checkForUpdates();
+  scheduleAfterAttempt(now);
+}
+
+bool OtaUpdater::shouldCheck(unsigned long now) const {
+  if (!_checkedSinceBoot) {
+    return true;
+  }
+  unsigned long elapsed = now - _lastCheckAt;
+  return elapsed >= OTA_CHECK_INTERVAL_MS;
+}
+
+void OtaUpdater::scheduleAfterAttempt(unsigned long now) {
+  _lastCheckAt = now;
+  _checkedSinceBoot = true;
+}
+
+void OtaUpdater::checkForUpdates() {
+  Serial.println("[OTA] Checking for firmware updates...");
+
+  String remoteVersion;
+  String firmwareUrl;
+  if (!fetchManifest(remoteVersion, firmwareUrl)) {
+    Serial.println("[OTA] Manifest fetch failed.");
+    return;
+  }
+
+  Serial.printf("[OTA] Current version: %s\n", CURRENT_FIRMWARE_VERSION);
+  Serial.printf("[OTA] Remote version: %s\n", remoteVersion.c_str());
+
+  int comparison = compareVersions(remoteVersion, CURRENT_FIRMWARE_VERSION);
+  if (comparison <= 0) {
+    Serial.println("[OTA] Device firmware is up to date.");
+    return;
+  }
+
+  Serial.println("[OTA] Newer firmware detected. Starting download...");
+  if (!downloadAndInstall(firmwareUrl, remoteVersion)) {
+    Serial.println("[OTA] Firmware download or install failed.");
+  }
+}
+
+bool OtaUpdater::fetchManifest(String &versionOut, String &firmwareUrlOut) {
+  String host;
+  if (!resolveHost(host)) {
+    return false;
+  }
+
+  WiFiClient netClient;
+  HttpClient httpClient(netClient, host.c_str(), BACKEND_PORT);
+  httpClient.setTimeout(OTA_HTTP_TIMEOUT_MS > 0 ? OTA_HTTP_TIMEOUT_MS :
+                                                kDefaultManifestTimeoutMs);
+
+  int statusCode = httpClient.get(OTA_MANIFEST_PATH);
+  if (statusCode < 0) {
+    Serial.printf("[OTA] HTTP connection failed: %d\n", statusCode);
+    httpClient.stop();
+    return false;
+  }
+
+  int responseCode = httpClient.responseStatusCode();
+  String responseBody = httpClient.responseBody();
+  httpClient.stop();
+
+  if (responseCode != 200) {
+    Serial.printf("[OTA] Manifest request returned HTTP %d\n", responseCode);
+    return false;
+  }
+
+  if (responseBody.length() == 0) {
+    Serial.println("[OTA] Manifest body was empty.");
+    return false;
+  }
+
+  StaticJsonDocument<512> doc;
+  DeserializationError err = deserializeJson(doc, responseBody);
+  if (err) {
+    Serial.printf("[OTA] Failed to parse manifest JSON: %s\n",
+                  err.c_str());
+    return false;
+  }
+
+  const char *version = doc["version"] | nullptr;
+  const char *firmwareUrl = doc["firmware_url"] | nullptr;
+  if (version == nullptr || firmwareUrl == nullptr) {
+    Serial.println("[OTA] Manifest missing required fields.");
+    return false;
+  }
+
+  versionOut = version;
+  firmwareUrlOut = firmwareUrl;
+  return true;
+}
+
+bool OtaUpdater::resolveHost(String &hostOut) {
+  hostOut = String(BACKEND_HOST);
+  if (!hostOut.endsWith(".local")) {
+    return true;
+  }
+
+  String hostname = hostOut;
+  hostname.replace(".local", "");
+  Serial.printf("[OTA] Resolving mDNS host %s.local...\n", hostname.c_str());
+  IPAddress resolved = MDNS.queryHost(hostname);
+  if (resolved == IPAddress(0, 0, 0, 0)) {
+    Serial.println("[OTA] Failed to resolve manifest host via mDNS.");
+    return false;
+  }
+
+  hostOut = resolved.toString();
+  Serial.printf("[OTA] Manifest host resolved to %s\n", hostOut.c_str());
+  return true;
+}
+
+bool OtaUpdater::downloadAndInstall(const String &url, const String &newVersion) {
+  HTTPClient client;
+  WiFiClient downloadClient;
+  if (!client.begin(downloadClient, url)) {
+    Serial.println("[OTA] Unable to begin firmware download.");
+    return false;
+  }
+
+  int httpCode = client.GET();
+  if (httpCode != HTTP_CODE_OK) {
+    Serial.printf("[OTA] Firmware download failed with HTTP %d\n", httpCode);
+    client.end();
+    return false;
+  }
+
+  int contentLength = client.getSize();
+  if (!Update.begin(contentLength > 0 ? contentLength : UPDATE_SIZE_UNKNOWN)) {
+    Serial.println("[OTA] Update.begin() failed.");
+    client.end();
+    return false;
+  }
+
+  WiFiClient *stream = client.getStreamPtr();
+  size_t written = Update.writeStream(*stream);
+  if (written == 0) {
+    Serial.println("[OTA] No data written during update.");
+    client.end();
+    return false;
+  }
+
+  if (!Update.end()) {
+    Serial.printf("[OTA] Update failed: %s\n", Update.errorString());
+    client.end();
+    return false;
+  }
+
+  if (!Update.isFinished()) {
+    Serial.println("[OTA] Update did not complete successfully.");
+    client.end();
+    return false;
+  }
+
+  Serial.printf("[OTA] Firmware %s installed successfully. Rebooting...\n",
+                newVersion.c_str());
+  client.end();
+  delay(100);
+  ESP.restart();
+  return true;
+}
+
+int OtaUpdater::compareVersions(const String &lhs, const String &rhs) {
+  size_t i = 0;
+  size_t j = 0;
+
+  auto readSegment = [](const String &value, size_t &index) {
+    long segment = 0;
+    bool hasDigits = false;
+    while (index < value.length() && value[index] != '.') {
+      char c = value[index];
+      if (c >= '0' && c <= '9') {
+        segment = segment * 10 + (c - '0');
+        hasDigits = true;
+      }
+      index++;
+    }
+    if (index < value.length() && value[index] == '.') {
+      index++;
+    }
+    return hasDigits ? segment : 0;
+  };
+
+  while (i < lhs.length() || j < rhs.length()) {
+    long lhsSegment = readSegment(lhs, i);
+    long rhsSegment = readSegment(rhs, j);
+    if (lhsSegment < rhsSegment) {
+      return -1;
+    }
+    if (lhsSegment > rhsSegment) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+

--- a/src/OtaUpdater.cpp
+++ b/src/OtaUpdater.cpp
@@ -9,7 +9,6 @@
 #include <ArduinoJson.h>
 #include <ESPmDNS.h>
 #include <HttpClient.h>
-#include <HTTPClient.h>
 #include <Update.h>
 #include <WiFiClient.h>
 
@@ -50,7 +49,8 @@ void OtaUpdater::checkForUpdates() {
 
   String remoteVersion;
   String firmwareUrl;
-  if (!fetchManifest(remoteVersion, firmwareUrl)) {
+  String manifestHost;
+  if (!fetchManifest(remoteVersion, firmwareUrl, manifestHost)) {
     Serial.println("[OTA] Manifest fetch failed.");
     return;
   }
@@ -65,19 +65,21 @@ void OtaUpdater::checkForUpdates() {
   }
 
   Serial.println("[OTA] Newer firmware detected. Starting download...");
-  if (!downloadAndInstall(firmwareUrl, remoteVersion)) {
+  if (!downloadAndInstall(firmwareUrl, manifestHost, remoteVersion)) {
     Serial.println("[OTA] Firmware download or install failed.");
   }
 }
 
-bool OtaUpdater::fetchManifest(String &versionOut, String &firmwareUrlOut) {
-  String host;
-  if (!resolveHost(host)) {
+bool OtaUpdater::fetchManifest(String &versionOut, String &firmwareUrlOut,
+                               String &resolvedHostOut) {
+  if (!resolveHost(String(BACKEND_HOST), resolvedHostOut)) {
     return false;
   }
 
   WiFiClient netClient;
-  HttpClient httpClient(netClient, host.c_str(), BACKEND_PORT);
+  netClient.setTimeout(OTA_HTTP_TIMEOUT_MS > 0 ? OTA_HTTP_TIMEOUT_MS :
+                                                   kDefaultManifestTimeoutMs);
+  HttpClient httpClient(netClient, resolvedHostOut.c_str(), BACKEND_PORT);
   httpClient.setTimeout(OTA_HTTP_TIMEOUT_MS > 0 ? OTA_HTTP_TIMEOUT_MS :
                                                 kDefaultManifestTimeoutMs);
 
@@ -102,7 +104,7 @@ bool OtaUpdater::fetchManifest(String &versionOut, String &firmwareUrlOut) {
     return false;
   }
 
-  StaticJsonDocument<512> doc;
+  JsonDocument doc(512);
   DeserializationError err = deserializeJson(doc, responseBody);
   if (err) {
     Serial.printf("[OTA] Failed to parse manifest JSON: %s\n",
@@ -122,71 +124,202 @@ bool OtaUpdater::fetchManifest(String &versionOut, String &firmwareUrlOut) {
   return true;
 }
 
-bool OtaUpdater::resolveHost(String &hostOut) {
-  hostOut = String(BACKEND_HOST);
-  if (!hostOut.endsWith(".local")) {
+bool OtaUpdater::resolveHost(const String &host, String &resolvedOut) {
+  if (!host.endsWith(".local")) {
+    resolvedOut = host;
     return true;
   }
 
-  String hostname = hostOut;
+  String hostname = host;
   hostname.replace(".local", "");
   Serial.printf("[OTA] Resolving mDNS host %s.local...\n", hostname.c_str());
   IPAddress resolved = MDNS.queryHost(hostname);
   if (resolved == IPAddress(0, 0, 0, 0)) {
-    Serial.println("[OTA] Failed to resolve manifest host via mDNS.");
+    Serial.printf("[OTA] Failed to resolve host %s via mDNS.\n",
+                  host.c_str());
     return false;
   }
 
-  hostOut = resolved.toString();
-  Serial.printf("[OTA] Manifest host resolved to %s\n", hostOut.c_str());
+  resolvedOut = resolved.toString();
+  Serial.printf("[OTA] Host %s resolved to %s\n", host.c_str(),
+                resolvedOut.c_str());
   return true;
 }
 
-bool OtaUpdater::downloadAndInstall(const String &url, const String &newVersion) {
-  HTTPClient client;
+bool OtaUpdater::downloadAndInstall(const String &url,
+                                    const String &manifestHost,
+                                    const String &newVersion) {
+  struct FirmwareRequest {
+    String connectionHost;
+    String hostHeader;
+    uint16_t port;
+    String path;
+  } request;
+
+  auto makeHostHeader = [](const String &host, uint16_t port) {
+    if (port == 80) {
+      return host;
+    }
+    String header(host);
+    header += ':';
+    header += port;
+    return header;
+  };
+
+  request.port = BACKEND_PORT;
+  request.connectionHost = manifestHost;
+  request.hostHeader = makeHostHeader(String(BACKEND_HOST), request.port);
+
+  String trimmedUrl = url;
+  trimmedUrl.trim();
+  if (trimmedUrl.isEmpty()) {
+    Serial.println("[OTA] Firmware URL from manifest was empty.");
+    return false;
+  }
+
+  bool isHttpUrl = trimmedUrl.startsWith("http://") ||
+                   trimmedUrl.startsWith("https://");
+  if (isHttpUrl) {
+    if (trimmedUrl.startsWith("https://")) {
+      Serial.println("[OTA] HTTPS firmware URLs are not supported by the OTA updater.");
+      return false;
+    }
+
+    int schemeLength = 7;  // length of "http://"
+    int pathIndex = trimmedUrl.indexOf('/', schemeLength);
+    String hostPort =
+        pathIndex < 0 ? trimmedUrl.substring(schemeLength)
+                      : trimmedUrl.substring(schemeLength, pathIndex);
+    if (hostPort.isEmpty()) {
+      Serial.println("[OTA] Firmware URL missing host component.");
+      return false;
+    }
+
+    String path = pathIndex < 0 ? String("/") : trimmedUrl.substring(pathIndex);
+    int colonIndex = hostPort.lastIndexOf(':');
+    String hostOnly = colonIndex >= 0 ? hostPort.substring(0, colonIndex)
+                                      : hostPort;
+    uint16_t port = colonIndex >= 0 ? hostPort.substring(colonIndex + 1).toInt()
+                                    : 80;
+    if (port == 0) {
+      port = 80;
+    }
+
+    String resolved;
+    if (!resolveHost(hostOnly, resolved)) {
+      return false;
+    }
+
+    request.connectionHost = resolved;
+    request.hostHeader = makeHostHeader(hostOnly, port);
+    request.port = port;
+    request.path = path;
+  } else {
+    request.path = trimmedUrl.startsWith("/") ? trimmedUrl : String("/") + trimmedUrl;
+  }
+
   WiFiClient downloadClient;
-  if (!client.begin(downloadClient, url)) {
-    Serial.println("[OTA] Unable to begin firmware download.");
+  downloadClient.setTimeout(OTA_HTTP_TIMEOUT_MS > 0 ? OTA_HTTP_TIMEOUT_MS :
+                                                       kDefaultManifestTimeoutMs);
+
+  Serial.printf("[OTA] Connecting to %s:%u for firmware download...\n",
+                request.connectionHost.c_str(), request.port);
+  if (!downloadClient.connect(request.connectionHost.c_str(), request.port)) {
+    Serial.println("[OTA] Connection to firmware host failed.");
     return false;
   }
 
-  int httpCode = client.GET();
-  if (httpCode != HTTP_CODE_OK) {
-    Serial.printf("[OTA] Firmware download failed with HTTP %d\n", httpCode);
-    client.end();
+  downloadClient.printf("GET %s HTTP/1.1\r\n", request.path.c_str());
+  downloadClient.printf("Host: %s\r\n", request.hostHeader.c_str());
+  downloadClient.print("Connection: close\r\n");
+  downloadClient.print("User-Agent: MusicBee-OTA/1.0\r\n\r\n");
+
+  unsigned long waitStart = millis();
+  while (downloadClient.connected() && !downloadClient.available()) {
+    if (OTA_HTTP_TIMEOUT_MS > 0 &&
+        millis() - waitStart > OTA_HTTP_TIMEOUT_MS) {
+      Serial.println("[OTA] Firmware host timed out before sending data.");
+      downloadClient.stop();
+      return false;
+    }
+    delay(10);
+  }
+
+  String statusLine = downloadClient.readStringUntil('\n');
+  statusLine.trim();
+  if (!statusLine.startsWith("HTTP/")) {
+    Serial.println("[OTA] Invalid HTTP response from firmware host.");
+    downloadClient.stop();
     return false;
   }
 
-  int contentLength = client.getSize();
+  int firstSpace = statusLine.indexOf(' ');
+  int secondSpace = statusLine.indexOf(' ', firstSpace + 1);
+  String codeStr =
+      firstSpace >= 0 ? statusLine.substring(firstSpace + 1, secondSpace > 0
+                                                                ? secondSpace
+                                                                : statusLine.length())
+                      : String();
+  int statusCode = codeStr.toInt();
+  if (statusCode != 200) {
+    Serial.printf("[OTA] Firmware download failed with HTTP %d\n", statusCode);
+    downloadClient.stop();
+    return false;
+  }
+
+  long contentLength = -1;
+  while (downloadClient.connected()) {
+    String line = downloadClient.readStringUntil('\n');
+    if (line.length() == 0) {
+      break;
+    }
+    line.trim();
+    if (line.length() == 0) {
+      break;
+    }
+
+    int colonIndex = line.indexOf(':');
+    if (colonIndex < 0) {
+      continue;
+    }
+
+    String headerName = line.substring(0, colonIndex);
+    String headerValue = line.substring(colonIndex + 1);
+    headerValue.trim();
+    headerName.toLowerCase();
+    if (headerName == "content-length") {
+      contentLength = headerValue.toInt();
+    }
+  }
+
   if (!Update.begin(contentLength > 0 ? contentLength : UPDATE_SIZE_UNKNOWN)) {
     Serial.println("[OTA] Update.begin() failed.");
-    client.end();
+    downloadClient.stop();
     return false;
   }
 
-  WiFiClient *stream = client.getStreamPtr();
-  size_t written = Update.writeStream(*stream);
+  size_t written = Update.writeStream(downloadClient);
   if (written == 0) {
     Serial.println("[OTA] No data written during update.");
-    client.end();
+    downloadClient.stop();
     return false;
   }
 
   if (!Update.end()) {
     Serial.printf("[OTA] Update failed: %s\n", Update.errorString());
-    client.end();
+    downloadClient.stop();
     return false;
   }
 
   if (!Update.isFinished()) {
     Serial.println("[OTA] Update did not complete successfully.");
-    client.end();
+    downloadClient.stop();
     return false;
   }
 
   Serial.printf("[OTA] Firmware %s installed successfully. Rebooting...\n",
                 newVersion.c_str());
-  client.end();
+  downloadClient.stop();
   delay(100);
   ESP.restart();
   return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include "RfidReader.h"
 #include "BackendClient.h"
 #include "EffectManager.h"
+#include "OtaUpdater.h"
 
 #if ENABLE_DEBUG_ACTIONS
 #  include "DebugActionServer.h"
@@ -26,6 +27,7 @@ static WifiManager wifi;
 static RfidReader rfid;
 static BackendClient backend;
 static EffectManager effects(LED_DATA_PIN, LED_COUNT_DEFAULT, LED_BRIGHTNESS_DEFAULT);
+static OtaUpdater otaUpdater;
 
 namespace {
 constexpr float kTailPrimaryFactor = 0.5f;
@@ -770,6 +772,8 @@ void loop() {
   }
   updateWifiVisualState(isConnected, now);
   wifiPreviouslyConnected = isConnected;
+
+  otaUpdater.loop(now, isConnected);
 
   MdnsQueryUpdate mdnsUpdate;
   if (fetchMdnsQueryUpdate(mdnsUpdate)) {


### PR DESCRIPTION
## Summary
- add configuration constants for OTA firmware version tracking and manifest location
- implement an OtaUpdater helper that polls the manifest, compares versions, and streams firmware updates
- invoke OTA checks from the main loop and document the new behaviour in the README

## Testing
- Not run (PlatformIO tooling is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3d13e3fd88320a9560e5778091d0f