### PR TITLE
Add rainbow card scanning LED effect

### DIFF
--- a/include/EffectManager.h
+++ b/include/EffectManager.h
@@ -27,6 +27,7 @@ public:
   void showFade(uint8_t startRed, uint8_t startGreen, uint8_t startBlue,
                 uint8_t endRed, uint8_t endGreen, uint8_t endBlue,
                 unsigned long durationMs, unsigned long now);
+  void showRainbow(unsigned long intervalMs, unsigned long now);
 
   void setBrightness(uint8_t brightness);
   uint8_t brightness() const { return _brightness; }
@@ -39,6 +40,7 @@ public:
   BreathingEffect &breathingEffect() { return _breathingEffect; }
   CometEffect &cometEffect() { return _cometEffect; }
   FadeEffect &fadeEffect() { return _fadeEffect; }
+  RainbowEffect &rainbowEffect() { return _rainbowEffect; }
 
 private:
   void activateEffect(Effect &effect, unsigned long now);
@@ -52,5 +54,6 @@ private:
   BreathingEffect _breathingEffect;
   CometEffect _cometEffect;
   FadeEffect _fadeEffect;
+  RainbowEffect _rainbowEffect;
 };
 

--- a/include/EffectManager.h
+++ b/include/EffectManager.h
@@ -28,6 +28,7 @@ public:
                 uint8_t endRed, uint8_t endGreen, uint8_t endBlue,
                 unsigned long durationMs, unsigned long now);
   void showRainbow(unsigned long intervalMs, unsigned long now);
+  void turnOff(unsigned long now);
 
   void setBrightness(uint8_t brightness);
   uint8_t brightness() const { return _brightness; }

--- a/include/Effects.h
+++ b/include/Effects.h
@@ -153,3 +153,21 @@ private:
   unsigned long _startTime;
 };
 
+class RainbowEffect : public Effect {
+public:
+  RainbowEffect(unsigned long intervalMs = 20UL);
+
+  void setInterval(unsigned long intervalMs);
+
+  void begin(unsigned long now) override;
+  void update(unsigned long now) override;
+
+private:
+  void draw();
+  uint32_t wheel(uint8_t position);
+
+  unsigned long _intervalMs;
+  unsigned long _lastStep;
+  uint8_t _offset;
+};
+

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -99,6 +99,14 @@ void EffectManager::showRainbow(unsigned long intervalMs, unsigned long now) {
   activateEffect(_rainbowEffect, now);
 }
 
+void EffectManager::turnOff(unsigned long now) {
+  uint32_t off = _strip.color(0, 0, 0);
+  _strip.setAll(off);
+  _strip.apply();
+  _activeEffect = nullptr;
+  Serial.printf("[Effects] Strip turned off at %lums\n", now);
+}
+
 void EffectManager::setBrightness(uint8_t brightness) {
   _brightness = brightness;
   _strip.setBrightness(brightness);

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -11,7 +11,8 @@ EffectManager::EffectManager(uint8_t dataPin, uint16_t ledCount, uint8_t default
       _snakeEffect(),
       _breathingEffect(),
       _cometEffect(),
-      _fadeEffect() {}
+      _fadeEffect(),
+      _rainbowEffect() {}
 
 void EffectManager::begin(unsigned long now) {
   (void)now;
@@ -90,6 +91,12 @@ void EffectManager::showFade(uint8_t startRed, uint8_t startGreen, uint8_t start
                 endBlue,
                 durationMs);
   activateEffect(_fadeEffect, now);
+}
+
+void EffectManager::showRainbow(unsigned long intervalMs, unsigned long now) {
+  _rainbowEffect.setInterval(intervalMs);
+  Serial.printf("[Effects] Activating Rainbow (interval %lums)\n", intervalMs);
+  activateEffect(_rainbowEffect, now);
 }
 
 void EffectManager::setBrightness(uint8_t brightness) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,7 +98,7 @@ public:
   void updateWifiState(bool isConnected, bool wasPreviouslyConnected, unsigned long now) {
     VisualState target = VisualState::WifiConnecting;
     if (isConnected) {
-      target = VisualState::WifiConnected;
+      target = VisualState::Idle;
     } else if (_initialized && wasPreviouslyConnected) {
       target = VisualState::WifiError;
     }
@@ -159,7 +159,7 @@ private:
   void applyState(VisualState state, unsigned long now) {
     switch (state) {
       case VisualState::Idle:
-        _effects.showSolidColor(0, 0, 0, now);
+        _effects.turnOff(now);
         break;
       case VisualState::WifiConnecting:
         _effects.showComet(0, 0, 255,
@@ -168,8 +168,7 @@ private:
                            kWifiCometIntervalMs, now);
         break;
       case VisualState::WifiConnected:
-        _effects.breathingEffect().setPeriod(1500);
-        _effects.showBreathing(0, 128, 255, now);
+        _effects.turnOff(now);
         break;
       case VisualState::WifiError:
         _effects.showFade(255, 0, 0, 80, 0, 0, kErrorFadeDurationMs, now);
@@ -442,6 +441,10 @@ static bool parseVisualState(const String &value, VisualState &state) {
   }
   if (normalized == "wifi_connected") {
     state = VisualState::WifiConnected;
+    return true;
+  }
+  if (normalized == "idle") {
+    state = VisualState::Idle;
     return true;
   }
   if (normalized == "wifi_error") {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,10 +33,10 @@ namespace {
 constexpr float kTailPrimaryFactor = 0.5f;
 constexpr float kTailSecondaryFactor = 0.2f;
 constexpr unsigned long kWifiCometIntervalMs = 40;
-constexpr unsigned long kCardSpinnerIntervalMs = 40;
 constexpr unsigned long kSuccessSpinIntervalMs = 28;
 constexpr unsigned long kErrorFadeDurationMs = 300;
 constexpr unsigned long kTransientEffectDurationMs = 2500;
+constexpr unsigned long kCardRainbowIntervalMs = 15;
 }
 
 enum class VisualState {
@@ -175,13 +175,10 @@ private:
         _effects.showFade(255, 0, 0, 80, 0, 0, kErrorFadeDurationMs, now);
         break;
       case VisualState::CardDetected:
-        _effects.showSolidColor(255, 255, 255, now);
+        _effects.showRainbow(kCardRainbowIntervalMs, now);
         break;
       case VisualState::CardScanning:
-        _effects.showComet(255, 255, 255,
-                           kTailPrimaryFactor, kTailSecondaryFactor,
-                           CometEffect::Direction::Clockwise,
-                           kCardSpinnerIntervalMs, now);
+        _effects.showRainbow(kCardRainbowIntervalMs, now);
         break;
       case VisualState::BackendSuccess:
         _effects.snakeEffect().setInterval(kSuccessSpinIntervalMs);


### PR DESCRIPTION
## Summary
- add a reusable rainbow animation effect for the LED strip and expose it through the effect manager
- switch card detection and scanning states to use the fast rainbow animation until a success or error occurs

## Testing
- `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5018e5d7483209c17507668ebe0d1